### PR TITLE
ci: bump juju to 3.4

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -13,5 +13,5 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.24/stable
-      juju-channel: 2.9/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -16,5 +16,5 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.24/stable
-      juju-channel: 2.9/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"


### PR DESCRIPTION
This PR changes the CI to use Juju version `3.4/stable`.